### PR TITLE
added support for field aliases

### DIFF
--- a/p4c_bm/__main__.py
+++ b/p4c_bm/__main__.py
@@ -49,6 +49,11 @@ def get_parser():
     parser.add_argument('--p4-prefix', type=str,
                         help='P4 name use for API function prefix',
                         default="prog", required=False)
+    parser.add_argument('--field-aliases', type=str,
+                        help='Path to file containing field aliases. '
+                        'In this file, each line contains a mapping with this '
+                        'format: "<alias> <full name of field>"',
+                        required=False)
     return parser
 
 
@@ -94,6 +99,11 @@ def main():
     if args.json:
         path_json = _validate_path(args.json)
 
+    if args.field_aliases:
+        path_field_aliases = _validate_path(args.field_aliases)
+    else:
+        path_field_aliases = None
+
     from_json = False
     if args.pd:
         path_pd = _validate_dir(args.pd)
@@ -120,7 +130,7 @@ def main():
             print "Error while building HLIR"
             sys.exit(1)
 
-        json_dict = gen_json.json_dict_create(h)
+        json_dict = gen_json.json_dict_create(h, path_field_aliases)
 
         if args.json:
             print "Generating json output to", path_json

--- a/tests/testdata/field_aliases/error_bad_field.txt
+++ b/tests/testdata/field_aliases/error_bad_field.txt
@@ -1,0 +1,2 @@
+egress_spec standard_metadata.egress_spec
+egress_spec_1 standard_metadata.egressspec

--- a/tests/testdata/field_aliases/error_bad_format.txt
+++ b/tests/testdata/field_aliases/error_bad_format.txt
@@ -1,0 +1,2 @@
+egress_spec standard_metadata.egress_spec
+standard_metadata.egress_spec

--- a/tests/testdata/field_aliases/sample_1.txt
+++ b/tests/testdata/field_aliases/sample_1.txt
@@ -1,0 +1,3 @@
+egress_spec standard_metadata.egress_spec
+egress_spec_1 standard_metadata.egress_spec
+egress_port standard_metadata.egress_port

--- a/tests/testdata/field_aliases/sample_2.txt
+++ b/tests/testdata/field_aliases/sample_2.txt
@@ -1,0 +1,2 @@
+egress_port standard_metadata.egress_spec
+egress_port standard_metadata.egress_port


### PR DESCRIPTION
Field aliases provide new names for P4 fields.
For example: using `egress_spec` as an alias for `standard_metadata.egress_spec` means that a bmv2 target can use `egress_spec` to refer to `standard_metadata.egress_spec`. This can increase portability of P4 programs.
Field aliases can be defined using the `--field-aliases` option. See `tests/testdata/field_aliases` for examples.
