### PR TITLE
better version tracking

### DIFF
--- a/p4c_bm/__main__.py
+++ b/p4c_bm/__main__.py
@@ -29,6 +29,7 @@ import gen_json
 import gen_pd
 import json
 from pkg_resources import resource_string
+import version
 
 
 def get_parser():
@@ -56,6 +57,8 @@ def get_parser():
     parser.add_argument('--p4-v1.1', action='store_true',
                         help='Run the compiler on a p4 v1.1 program',
                         default=False, required=False)
+    parser.add_argument('--version', '-v', action='version',
+                        version=version.get_version_str())
     return parser
 
 

--- a/p4c_bm/_version.py
+++ b/p4c_bm/_version.py
@@ -20,10 +20,5 @@
 
 # -*- coding: utf-8 -*-
 
-from version import get_version_str
-
-__author__ = 'Antonin Bas'
-__email__ = 'antonin@barefootnetworks.com'
-__version__ = get_version_str()
-
-del get_version_str
+version = '0.9.0'
+build_version = None

--- a/p4c_bm/version.py
+++ b/p4c_bm/version.py
@@ -20,10 +20,16 @@
 
 # -*- coding: utf-8 -*-
 
-from version import get_version_str
+import _version
 
-__author__ = 'Antonin Bas'
-__email__ = 'antonin@barefootnetworks.com'
-__version__ = get_version_str()
 
-del get_version_str
+def get_version_str():
+    build_version = _version.build_version
+    if build_version is None:
+        try:
+            import subprocess
+            build_version = subprocess.check_output(["git", "rev-parse", "@"])
+            build_version = build_version[:8]
+        except:  # pragma: no cover
+            build_version = 'unknown'
+    return "-".join([_version.version, build_version])

--- a/tests/test_p4c_bm.py
+++ b/tests/test_p4c_bm.py
@@ -164,6 +164,9 @@ def test_main(tmpdir):
     assert call_main(["-h"]) == 0
     assert call_main(["--help"]) == 0
 
+    assert call_main(["-v"]) == 0
+    assert call_main(["--version"]) == 0
+
     assert call_main([]) != 0
 
     assert call_main([input_p4]) == 0


### PR DESCRIPTION
- `_version.py` is checked in and includes version number and build version number
- when build version number is `None`, `version.py` gets a SHA from git
