### PR TITLE
setting 'cwd' when running 'git rev-parse' to get version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ pd_mk/p4_pd
 build_setuptools
 
 install_files.txt
+
+p4c_bm/_version_str.py

--- a/p4c_bm/version.py
+++ b/p4c_bm/version.py
@@ -28,7 +28,14 @@ def get_version_str():
     if build_version is None:
         try:
             import subprocess
-            build_version = subprocess.check_output(["git", "rev-parse", "@"])
+            import os
+            p = subprocess.Popen(["git", "rev-parse", "@"],
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 cwd=os.path.dirname(os.path.abspath(__file__)))
+            out, _ = p.communicate()  # ignore stderr
+            if p.returncode:  # pragma: no cover
+                raise subprocess.CalledProcessError
+            build_version = out
             build_version = build_version[:8]
         except:  # pragma: no cover
             build_version = 'unknown'

--- a/p4c_bm/version.py
+++ b/p4c_bm/version.py
@@ -38,5 +38,10 @@ def get_version_str():
             build_version = out
             build_version = build_version[:8]
         except:  # pragma: no cover
-            build_version = 'unknown'
+            # we try to find a cached version
+            try:
+                import _version_str
+                return _version_str.version_str
+            except:
+                build_version = 'unknown'
     return "-".join([_version.version, build_version])

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ with open(os.path.join(SETUP_PY_PATH, 'README.rst')) as readme_file:
 with open(os.path.join(SETUP_PY_PATH, 'HISTORY.rst')) as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
+with open(os.path.join(SRC_PATH, "_version_str.py"), 'w') as version_f:
+    version_f.write("# This file is auto-generated\n")
+    version_f.write("version_str = '{}'\n".format(p4c_bm.__version__))
+
 requirements = [
     # TODO: put package requirements here
     'p4-hlir',


### PR DESCRIPTION
to avoid `fatal: Not a git repository` error
