### PR TITLE
allow p4_header_stack arguments in actions

### DIFF
--- a/p4c_bm/__main__.py
+++ b/p4c_bm/__main__.py
@@ -80,10 +80,11 @@ def _validate_path(path):
 
 # to be used for a source file
 def _validate_file(path):
-    _validate_path(path)
+    path = _validate_path(path)
     if not os.path.exists(path):
         print path, "does not exist"
         sys.exit(1)
+    return path
 
 
 def _validate_dir(path):

--- a/p4c_bm/gen_json.py
+++ b/p4c_bm/gen_json.py
@@ -758,7 +758,7 @@ def field_list_to_id(p4_field_list):
     return idx
 
 
-def dump_actions(json_dict, hlir):
+def dump_actions(json_dict, hlir, p4_v1_1=False):
     actions = []
     action_id = 0
 
@@ -825,7 +825,7 @@ def dump_actions(json_dict, hlir):
                 elif type(arg) is p4.p4_header_instance:
                     arg_dict["type"] = "header"
                     arg_dict["value"] = arg.name
-                elif type(arg) is p4.p4_header_stack:
+                elif p4_v1_1 and type(arg) is p4.p4_header_stack:
                     arg_dict["type"] = "header_stack"
                     arg_dict["value"] = re.sub(r'\[.*\]', '', arg.name)
                 elif type(arg) is p4.p4_signature_ref:
@@ -1179,7 +1179,7 @@ def json_dict_create(hlir, path_field_aliases=None, p4_v1_1=False):
     dump_parsers(json_dict, hlir)
     dump_deparsers(json_dict, hlir)
     dump_meters(json_dict, hlir)
-    dump_actions(json_dict, hlir)
+    dump_actions(json_dict, hlir, p4_v1_1=p4_v1_1)
     dump_pipelines(json_dict, hlir)
     dump_calculations(json_dict, hlir)
     dump_checksums(json_dict, hlir)

--- a/p4c_bm/gen_json.py
+++ b/p4c_bm/gen_json.py
@@ -825,6 +825,9 @@ def dump_actions(json_dict, hlir):
                 elif type(arg) is p4.p4_header_instance:
                     arg_dict["type"] = "header"
                     arg_dict["value"] = arg.name
+                elif type(arg) is p4.p4_header_stack:
+                    arg_dict["type"] = "header_stack"
+                    arg_dict["value"] = re.sub(r'\[.*\]', '', arg.name)
                 elif type(arg) is p4.p4_signature_ref:
                     arg_dict["type"] = "runtime_data"
                     arg_dict["value"] = arg.idx

--- a/tests/p4_programs/v1_1/push_pop.p4
+++ b/tests/p4_programs/v1_1/push_pop.p4
@@ -1,0 +1,98 @@
+header_type ethernet_t {
+    fields {
+        bit<48>     dst;
+        bit<48>     src;
+        bit<16>     type_;
+    }
+}
+
+header_type vlan_t {
+    fields {
+        bit<3>      prio;
+        bit<1>      id;
+        bit<12>     vlan;
+        bit<16>     type_;
+    }
+}
+
+header_type ipv4_t {
+    fields {
+        bit<4>      version;
+        bit<4>      ihl;
+        bit<8>      tos;
+        bit<16>     len;
+        bit<16>     id;
+        bit<3>      flags;
+        bit<13>     frag;
+        bit<8>      ttl;
+        bit<8>      proto;
+        bit<16>     chksum;
+        bit<32>     src;
+        bit<32>     dst;
+    }
+}
+
+header ethernet_t ethernet;
+header vlan_t vlan_0[3];
+header ipv4_t ipv4;
+
+parser start {
+    return parse_ethernet;
+}
+
+parser parse_ethernet {
+    extract(ethernet);
+    return select(latest.type_) {
+        0x8100  : parse_vlan_0;
+        0x0800  : parse_ipv4;
+        default : ingress;
+    }
+}
+
+parser parse_vlan_0 {
+    extract(vlan_0[next]);
+    return select(latest.type_) {
+        0x8100  : parse_vlan_0;
+        0x0800  : parse_ipv4;
+        default : ingress;
+    }
+}
+
+parser parse_ipv4 {
+    extract(ipv4);
+    return ingress;
+}
+
+action action_0() {
+    pop(vlan_0, 1);
+}
+table table_0 {
+    reads   { ethernet.dst : exact; }
+    actions { action_0; }
+    size    : 64;
+}
+
+action action_1() {
+    push(vlan_0, 1);
+
+    modify_field(vlan_0[0].prio, 0);
+    modify_field(vlan_0[0].id, 0);
+    modify_field(vlan_0[0].vlan, 1);
+    modify_field(vlan_0[0].type_, ethernet.type_);
+
+    modify_field(ethernet.type_, 0x8100);
+}
+table table_1 {
+    reads   { ethernet.dst : exact; }
+    actions { action_1; }
+    size    : 64;
+}
+
+control ingress {
+    if (valid(vlan_0[1])) {
+        apply(table_0);     // pop
+    }
+    else {
+        apply(table_1);     // push
+    }
+}


### PR DESCRIPTION
In P4v1.1 the add_header() and remove_header() primitives take p4_header_stack objects as arguments.

Are the lines https://github.com/p4lang/p4c-bm/blob/master/p4c_bm/gen_json.py#L862-L866 needed? I think they are for P4v1.0, but I'm not sure.
