### PR TITLE
Don't use pip editable mode when installing deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 wheel==0.23.0
 Tenjin==1.1.1
--e git+https://github.com/p4lang/p4-hlir.git#egg=p4-hlir
+git+https://github.com/p4lang/p4-hlir.git#egg=p4-hlir

--- a/requirements_v1_1.txt
+++ b/requirements_v1_1.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/p4lang/p4-hlir.git@p4v1.1#egg=p4-hlir-v1.1
+git+https://github.com/p4lang/p4-hlir.git@p4v1.1#egg=p4-hlir-v1.1


### PR DESCRIPTION
Not using -e anymore when installing p4-hlir from git. This was causing
issues when p4-hlir was also installed separately. Long story short, the
easy_install.pth file was pointing p4_hlir package to p4_hlir_v1_1 local
installation. Removing -e probably does not address the root casue of
the issue (which is the p4_hlir symlink in the p4v1.1 branch of the
p4-hlir repo), but it is an ok workaround for now.
