### PR TITLE
Use root correctly in the setup.py install hook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,10 @@ class CustomInstall(install):
         global install_lib
         assert(install_lib is None)
         install_lib = os.path.abspath(self.install_lib)
+        # if a root was specified we remove it from the install path
+        if self.root is not None:
+            assert(install_lib.startswith(self.root))
+            install_lib = install_lib[len(self.root):]
         install.run(self)
 
 class CustomInstallScripts(install_scripts):


### PR DESCRIPTION
When hard-coding the library installation path in the scripts, we need
to make sure to remove the root from it, to keep only the prefix.