### PR TITLE
Issue a warning when header not in parse graph

### DIFF
--- a/tests/p4_programs/added_header_not_in_parser_warn.p4
+++ b/tests/p4_programs/added_header_not_in_parser_warn.p4
@@ -1,0 +1,30 @@
+parser start {
+    return ingress;
+}
+
+table my_t {
+    reads {
+        standard_metadata.ingress_port : exact;
+    }
+    actions {
+        my_a;
+    }
+}
+
+header_type useless {
+    fields {
+        f : 32;
+    }
+}
+header useless h;
+
+header useless hs[3];
+
+action my_a() {
+    add_header(h);
+    push(hs);
+}
+
+control ingress {
+    apply(my_t);
+}


### PR DESCRIPTION
If the control flow tries to add this header by calling the add_header
or push primitives.