### PR TITLE
Check for direct registers and fail

### DIFF
--- a/p4c_bm/gen_json.py
+++ b/p4c_bm/gen_json.py
@@ -1407,6 +1407,9 @@ def dump_registers(json_dict, hlir, keep_pragmas=False):
     registers = []
     id_ = 0
     for name, p4_register in hlir.p4_registers.items():
+        if p4_register.binding and (p4_register.binding[0] == p4.P4_DIRECT):
+            LOG_CRITICAL("'{}' is a direct register; direct registers are not "
+                         "supported by bmv2".format(name))
         register_dict = OrderedDict()
         register_dict["name"] = name
         register_dict["id"] = id_

--- a/tests/p4_programs/negative_direct_register.p4
+++ b/tests/p4_programs/negative_direct_register.p4
@@ -1,0 +1,36 @@
+/* Copyright 2013-present Barefoot Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+parser start { return ingress; }
+
+@pragma dont_trim
+register my_register {
+    width : 16;
+    direct : my_t;
+}
+
+action my_action(param) {
+    // not defined for direct registers anyway...
+    // register_write(my_register, param);
+}
+
+table my_t {
+    reads { standard_metadata.egress_spec : exact; }
+    actions { my_action; }
+}
+
+control ingress { apply(my_t); }
+
+control egress { }


### PR DESCRIPTION
Add a check for the presence of direct registers and exit compilation
with an error message if there is one. Note that the register_write and
register_read primitives are not defined for direct registers anyway, as
the index parameter is mandatory.