### PR TITLE
Support new format for notification messages

### DIFF
--- a/p4c_bm/templates/src/pd_ageing.cpp
+++ b/p4c_bm/templates/src/pd_ageing.cpp
@@ -44,13 +44,14 @@ AgeingState *device_state[NUM_DEVICES];
 
 typedef struct {
   char sub_topic[4];
-  int switch_id;
-  int cxt_id;
+  uint64_t switch_id;
+  uint32_t cxt_id;
   uint64_t buffer_id;
   int table_id;
   unsigned int num_entries;
-  char _padding[4];
 } __attribute__((packed)) ageing_hdr_t;
+
+static_assert(sizeof(ageing_hdr_t) == 32u, "Invalid size for ageing header");
 
 }  // namespace
 

--- a/p4c_bm/templates/src/pd_learning.cpp
+++ b/p4c_bm/templates/src/pd_learning.cpp
@@ -98,13 +98,14 @@ void bytes_to_field<4>(const char *bytes, char *field) {
 
 typedef struct {
   char sub_topic[4];
-  int switch_id;
-  int cxt_id;
+  uint64_t switch_id;
+  uint32_t cxt_id;
   int list_id;
   unsigned long long buffer_id;
   unsigned int num_samples;
-  char _padding[4];
 } __attribute__((packed)) learn_hdr_t;
+
+static_assert(sizeof(learn_hdr_t) == 32u, "Invalid size for learn header");
 
 
 //:: for lq_name, lq in learn_quantas.items():


### PR DESCRIPTION
bmv2 now support 64-bit device ids. As a result the format of these
messages has changed to accomodate the larger ids. This means that the
PD code that parses these messages had to be updated. This doesn't
affect the PD interface at all.