### PR TITLE
Fail compilation if P4 program includes metadata initializer

### DIFF
--- a/p4c_bm/gen_json.py
+++ b/p4c_bm/gen_json.py
@@ -157,6 +157,15 @@ def dump_headers(json_dict, hlir, keep_pragmas=False):
         if keep_pragmas:
             add_pragmas(header_instance_dict, p4_header_instance)
 
+        for p4_field in p4_header_instance.fields:
+            if p4_field.default is not None and p4_field.default != 0:
+                LOG_CRITICAL(
+                    "In file '{}' at line {}: "
+                    "non-zero metadata initialization is not supported by this "
+                    "backend; field '{}' cannot be initialized to {}".format(
+                        p4_header_instance.filename, p4_header_instance.lineno,
+                        str(p4_field), p4_field.default))
+
         headers.append(header_instance_dict)
 
     json_dict["headers"] = headers

--- a/tests/p4_programs/negative_metadata_initializer.p4
+++ b/tests/p4_programs/negative_metadata_initializer.p4
@@ -1,0 +1,21 @@
+header_type meta_t {
+    fields {
+        x : 16;
+        y : 16;
+        z : 16;
+    }
+}
+
+@pragma dont_trim
+metadata meta_t meta {
+    x : 33;
+    y : 44;
+    z : 55;
+};
+
+parser start {
+    return ingress;
+}
+control ingress { }
+
+control egress { }


### PR DESCRIPTION
This is a P4_14 feature which is not supported directly by bmv2. Rather
than trying to emit JSON "code" for it (e.g. with set_metadata calls in
the parser), we reject the program.